### PR TITLE
Rename .sharp to .sharp-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install sharp.css
 
 ## [Classes](https://ryanve.github.io/sharp.css/)
 
-### .sharp
+### .sharp-all
 
 Sharpen all corners.
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ code { font: inherit }
 </header>
 
 <figure class="p3 mb0">
-  <code class="p1 mb1 mr1 mr0-last inline-block scheme-2 rounded sharp">.sharp</code>
+  <code class="p1 mb1 mr1 mr0-last inline-block scheme-2 rounded sharp-all">.sharp-all</code>
   <code class="p1 mb1 mr1 mr0-last inline-block scheme-2 rounded sharp-top">.sharp-top</code>
   <code class="p1 mb1 mr1 mr0-last inline-block scheme-2 rounded sharp-bottom">.sharp-bottom</code>
   <code class="p1 mb1 mr1 mr0-last inline-block scheme-2 rounded sharp-right">.sharp-right</code>

--- a/sharp.css
+++ b/sharp.css
@@ -1,4 +1,4 @@
-.sharp { border-radius: 0 }
+.sharp-all { border-radius: 0 }
 .sharp-top { border-top-left-radius: 0; border-top-right-radius: 0 }
 .sharp-left { border-top-left-radius: 0; border-bottom-left-radius: 0 }
 .sharp-right { border-top-right-radius: 0; border-bottom-right-radius: 0 }


### PR DESCRIPTION
`.sharp-all` seems easier to find in a codebase than `.sharp` does and fits convention with the other classes