### PR TITLE
Use text because markdown misinterprets semantics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-[CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/)
+CC0 1.0 Universal
 
 Statement of Purpose
 
@@ -111,3 +111,6 @@ Affirmer's express Statement of Purpose.
   d. Affirmer understands and acknowledges that Creative Commons is not a
   party to this document and has no duty or obligation with respect to this
   CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>


### PR DESCRIPTION
Exactly as described on https://choosealicense.com/licenses/cc0-1.0/